### PR TITLE
fix: typo in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ But don't panic! We’ve left a digital trail of breadcrumbs for you. 🍞
 
 ## 🔙 Here’s how to get back on track:
 
-[👉 Take me home, country roads ⤴️]([https://civictechwr.org)]
+[👉 Take me home, country roads ⤴️](https://civictechwr.org)
 
 Or you can:
 - 🔍 Double-check the URL (even autocorrect gets it wrong sometimes)


### PR DESCRIPTION
The build is failing because there is a typo in index.md. See job failure: https://github.com/CivicTechWR/CTWR-Organization-Documentation/actions/runs/15471573638/job/43557045246

<img width="1435" alt="Screenshot 2025-06-05 at 10 41 27 PM" src="https://github.com/user-attachments/assets/9f1f17ca-1b54-4fe7-877c-0d927eabd6d5" />
