### PR TITLE
Add gitleaks scan workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,27 @@
+name: Gitleaks Scan
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          log-level: warn
+          redact: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary
- add a gitleaks workflow that scans pushes, pull requests, and a weekly schedule for potential secrets
- pass along the GitHub Actions token and the organization gitleaks license so the action can validate and report findings

## Background
This repository did not previously have automated secret scanning. Adding gitleaks here brings it in line with the rest of the organization: every contribution is checked, the weekly run catches anything that slips through, and the token lets the action annotate PRs for faster response. The workflow mirrors the shared pattern we maintain in the `.github` repo.

## Testing
- not run (workflow only)

@CivicTechWR/organizers please review.
